### PR TITLE
expose component in package itself

### DIFF
--- a/app/components/radio-button.js
+++ b/app/components/radio-button.js
@@ -1,0 +1,3 @@
+import EmberRadioButton from 'ember-radio-buttons/components/radio-button';
+
+export default EmberRadioButton;

--- a/readme.md
+++ b/readme.md
@@ -13,21 +13,12 @@ This repo is just using the work of [FellowMD](https://gist.github.com/FellowMD)
 To install, run
 
 ```
-npm install ember-radio-buttons --save
+ember install:addon ember-radio-buttons
 ```
 
 and that's it!
 
 ## Usage
-To use this addon you need to expose the component in your app. Add this file to your components directory:
-```js
-// app/components/radio-button.js
-import EmberRadioButton from 'ember-radio-buttons';
-
-export default EmberRadioButton;
-```
-
-This will exposes a {{radio-button}} component that gives you a working implementation of Radio Buttons.
 
 ```hbs
 {{radio-button value='one' checked=selectedNumber}}


### PR DESCRIPTION
We can expose the component in this addon directly. So there is no need to add code yourself after adding this component as dependency.

I'm not sure if `index.js` is still needed. Looks bit like duplicated code now.